### PR TITLE
Add simple fade plugin and it's consumer in react

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ The Only Headless CMS with a Visual Editor.
 - [storyblok-java-sdk](https://github.com/geilix10/storyblok-java-sdk) - Richtextresolver for Java.
 - [vuestorefront-storyblok-sync](https://github.com/kodbruket/vsf-storyblok-sync) - Storyblok integration for Vue Storefront.
 
+##### Plugins
+
+- [component-fade-plugin](https://github.com/storyblok-extended/component-fade-plugin) - Plugin for easy 'fade' transition.
+- [component-fade-plugin-react-consumer](https://github.com/storyblok-extended/component-fade-plugin-react-consumer) - HOC React component which consumes `component-fade-plugin` returned data.
+
 ### Projects built with Storyblok
 
 - [Storyblok](https://www.storyblok.com) - The awesome website of the Storyblok (of course).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ The Only Headless CMS with a Visual Editor.
 
 #### Community
 
-
 - [storyblok-migrate](https://github.com/maoberlehner/storyblok-migrate) - Migration tool from Storyblok (Import/Export of schemas and content).
 - [storyblok-rich-text-renderer](https://github.com/MarvinRudolph/storyblok-rich-text-renderer) - Rich Text Renderer for VueJS/NuxtJS
 - [sb-mig](https://github.com/marckraw/sb-mig) - CLI for the Management API of Storyblok.
@@ -70,7 +69,9 @@ The Only Headless CMS with a Visual Editor.
 - [storyblok-java-sdk](https://github.com/geilix10/storyblok-java-sdk) - Richtextresolver for Java.
 - [vuestorefront-storyblok-sync](https://github.com/kodbruket/vsf-storyblok-sync) - Storyblok integration for Vue Storefront.
 
-##### Plugins
+### Field Plugins
+
+#### Community
 
 - [component-fade-plugin](https://github.com/storyblok-extended/component-fade-plugin) - Plugin for easy 'fade' transition.
 - [component-fade-plugin-react-consumer](https://github.com/storyblok-extended/component-fade-plugin-react-consumer) - HOC React component which consumes `component-fade-plugin` returned data.


### PR DESCRIPTION
I've created plugin for simple transition fade in with basic transition methods (future will be added cubic beziers)

But also i have HOC react consumer of this plugin, so it's a full solution.
I'm very interested in figuring out some kind of method for shipping plugins + components using this plugins.

