### PR TITLE
Adding Raycast extension to Community section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The Only Headless CMS with a Visual Editor.
 - [C# Storyblok](https://github.com/adliance/Storyblok) - C# SDK to access Storyblok API.
 - [storyblok-api-go](https://github.com/teamexos/storyblok-api-go) - Golang SDK to access Storyblok API.
 - [gatsby-storyblok-image](https://github.com/bejamas/gatsby-storyblok-image) - Gatsby community plugin to enable gatsby-image with Storyblok.
+- [Storyblok Raycast Extension](https://www.raycast.com/Rob/storyblok) - Manage your Storyblok spaces, their stories, assets, contributors, and activities, from your fingertips with Raycast. View and contribute [the sourcecode for this extension here](https://github.com/raycast/extensions/tree/main/extensions/storyblok).  
 
 ### Field Plugins
 


### PR DESCRIPTION
Adds a link to the Storyblok Raycast Extension to the README. Was advised by @siddharthdayalwal to [add this in a message from Discord](https://discord.com/channels/700316478792138842/1229449980113190955/1232339531944955985)!